### PR TITLE
Fix for SHA-1 is a Weak Hash Function

### DIFF
--- a/sonar-integration-test/WebGoat-Lessons/http-only/src/main/java/org/owasp/webgoat/plugin/HttpOnly.java
+++ b/sonar-integration-test/WebGoat-Lessons/http-only/src/main/java/org/owasp/webgoat/plugin/HttpOnly.java
@@ -183,7 +183,7 @@ public class HttpOnly extends LessonAdapter
 
         try
         {
-            md = MessageDigest.getInstance("SHA");
+            md = MessageDigest.getInstance("SHA-256");
             buffer = new Date().toString().getBytes();
 
             md.update(buffer);


### PR DESCRIPTION
[Issue Link](https://reshift.reshiftsecurity.com/issues/eyJ0YWdfaWQiOiB7InJlcG9zaXRvcnlfaWQiOiB7InByb3ZpZGVyX2lkIjogIkdpdGh1YiIsICJwcm92aWRlcl9vd25lcl9pZCI6ICI0ODEwMzYxOSIsICJwcm92aWRlcl9yZXBvc2l0b3J5X2lkIjogIk1ERXdPbEpsY0c5emFYUnZjbmt5TkRNMk5qZzVPVEU9In0sICJuYW1lIjogIm9yaWdpbi9IRUFEIn0sICJyZXBvcnRfaWQiOiA1NzA2fQ%3D%3D?issue_id=eyJyZXBvcnRfaWQiOiB7InRhZ19pZCI6IHsicmVwb3NpdG9yeV9pZCI6IHsicHJvdmlkZXJfaWQiOiAiR2l0aHViIiwgInByb3ZpZGVyX293bmVyX2lkIjogIjQ4MTAzNjE5IiwgInByb3ZpZGVyX3JlcG9zaXRvcnlfaWQiOiAiTURFd09sSmxjRzl6YVhSdmNua3lORE0yTmpnNU9URT0ifSwgIm5hbWUiOiAib3JpZ2luL0hFQUQifSwgInJlcG9ydF9pZCI6IDU3MDZ9LCAiaXNzdWVfaWQiOiAxNjY0MjY2fQ%3D%3D)

SHA-1 previously replaced weaker hashing algorithms such as MD1/2/5 however as of August 5, 2015, NIST has recommended that all federal agencies stop using SHA-1 for digital signatures, timestamps and other applications that require collision resistance. Other major vendors such as Microsoft, Google, Mozilla, and Apple have also followed suit. Evidence of this deprecation can be found within the IETF draft, [Deprecating MD5 and SHA1 in TLS 1.2](https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html), which leverages the guidelines of [RFC 7525](https://tools.ietf.org/html/rfc7525) recommending only SHA-256 or -384 be used.


SHA-1 is not recommended and a replacement such as SHA-2 (-224, -256, -384, -512) should be considered

Vulnerable Code
Message Digest in Java:
```
public static String encryptWithSHA1(String input) {
    MessageDigest md = MessageDigest.getInstance("SHA-1");
    byte[] messageDigest = md.digest(input.getBytes());
    BigInteger no = new BigInteger(1, messageDigest);
    String hashtext = no.toString(16);
    while (hashtext.length() < 32) {
        hashtext = "0" + hashtext;
    }
    return hashtext;
}
```

Solutions:

Guava Library:
```
String sha256hex = Hashing.sha256()
  .hashString(originalString, StandardCharsets.UTF_8)
  .toString();
```

Apache Commons:
```
String sha256hex = DigestUtils.sha256Hex(originalString);
```

Bouncy Castle Library:
```
MessageDigest digest = MessageDigest.getInstance("SHA-256");
byte[] hash = digest.digest(
  originalString.getBytes(StandardCharsets.UTF_8));
String sha256hex = new String(Hex.encode(hash));
```

MessageDigest Class in Java:
```
final MessageDigest digest = MessageDigest.getInstance(SHA3_256);
final byte[] hashbytes = digest.digest(
  originalString.getBytes(StandardCharsets.UTF_8));
String sha3_256hex = bytesToHex(hashbytes);
```
